### PR TITLE
Fix typo in verbose output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ end
 ```console
 # Running:
 
-[MiniestRetry] retry 'test_fail' count: 1,  msg: test fail
-[MiniestRetry] retry 'test_fail' count: 2,  msg: test fail
-[MiniestRetry] retry 'test_fail' count: 3,  msg: test fail
+[MinitestRetry] retry 'test_fail' count: 1,  msg: test fail
+[MinitestRetry] retry 'test_fail' count: 2,  msg: test fail
+[MinitestRetry] retry 'test_fail' count: 3,  msg: test fail
 F
 
 Finished in 0.002479s, 403.4698 runs/s, 403.4698 assertions/s.
@@ -76,4 +76,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/y-yagi
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/minitest/retry.rb
+++ b/lib/minitest/retry.rb
@@ -26,7 +26,7 @@ module Minitest
         if !result.failures.empty? && !result.skipped?
           retry_count.times do |count|
             if Minitest::Retry.verbose && Minitest::Retry.io
-              msg = "[MiniestRetry] retry '%s' count: %s,  msg: %s\n" %
+              msg = "[MinitestRetry] retry '%s' count: %s,  msg: %s\n" %
                 [method_name, count + 1, result.failures.join(",")]
               Minitest::Retry.io.puts(msg)
             end

--- a/test/minitest/retry_test.rb
+++ b/test/minitest/retry_test.rb
@@ -28,9 +28,9 @@ class Minitest::RetryTest < Minitest::Test
       Minitest::Runnable.run_one_method(retry_test, :fail, self.reporter)
     end
     expect = <<-EOS
-[MiniestRetry] retry 'fail' count: 1,  msg: fail test
-[MiniestRetry] retry 'fail' count: 2,  msg: fail test
-[MiniestRetry] retry 'fail' count: 3,  msg: fail test
+[MinitestRetry] retry 'fail' count: 1,  msg: fail test
+[MinitestRetry] retry 'fail' count: 2,  msg: fail test
+[MinitestRetry] retry 'fail' count: 3,  msg: fail test
     EOS
 
     refute reporter.passed?
@@ -50,9 +50,9 @@ class Minitest::RetryTest < Minitest::Test
       Minitest::Runnable.run_one_method(retry_test, :fail, self.reporter)
     end
     expect = <<-EOS
-[MiniestRetry] retry 'fail' count: 1,  msg: Expected: 3
+[MinitestRetry] retry 'fail' count: 1,  msg: Expected: 3
   Actual: 1
-[MiniestRetry] retry 'fail' count: 2,  msg: Expected: 3
+[MinitestRetry] retry 'fail' count: 2,  msg: Expected: 3
   Actual: 2
     EOS
 
@@ -71,11 +71,11 @@ class Minitest::RetryTest < Minitest::Test
       Minitest::Runnable.run_one_method(retry_test, :fail, self.reporter)
     end
     expect = <<-EOS
-[MiniestRetry] retry 'fail' count: 1,  msg: fail test
-[MiniestRetry] retry 'fail' count: 2,  msg: fail test
-[MiniestRetry] retry 'fail' count: 3,  msg: fail test
-[MiniestRetry] retry 'fail' count: 4,  msg: fail test
-[MiniestRetry] retry 'fail' count: 5,  msg: fail test
+[MinitestRetry] retry 'fail' count: 1,  msg: fail test
+[MinitestRetry] retry 'fail' count: 2,  msg: fail test
+[MinitestRetry] retry 'fail' count: 3,  msg: fail test
+[MinitestRetry] retry 'fail' count: 4,  msg: fail test
+[MinitestRetry] retry 'fail' count: 5,  msg: fail test
     EOS
 
     refute reporter.passed?


### PR DESCRIPTION
Thanks for the great gem. This fixes a small typo in the verbose output.