### PR TITLE
Improve message information when an unexpected error occurs

### DIFF
--- a/lib/minitest/retry.rb
+++ b/lib/minitest/retry.rb
@@ -27,7 +27,7 @@ module Minitest
           retry_count.times do |count|
             if Minitest::Retry.verbose && Minitest::Retry.io
               msg = "[MinitestRetry] retry '%s' count: %s,  msg: %s\n" %
-                [method_name, count + 1, result.failures.join(",")]
+                [method_name, count + 1, result.failures.map { |f| f.message }.join(",")]
               Minitest::Retry.io.puts(msg)
             end
 

--- a/test/minitest/retry_test.rb
+++ b/test/minitest/retry_test.rb
@@ -37,6 +37,26 @@ class Minitest::RetryTest < Minitest::Test
     assert_equal expect, output
   end
 
+  def test_display_retry_msg_for_unexpected_exception
+    output = capture_stdout do
+      retry_test = Class.new(Minitest::Test) do
+        Minitest::Retry.use!
+        def fail
+          raise 'parsing error'
+        end
+      end
+      Minitest::Runnable.run_one_method(retry_test, :fail, self.reporter)
+    end
+    expect = <<-EOS
+[MinitestRetry] retry 'fail' count: 1,  msg: RuntimeError: parsing error\n    #{__FILE__}:45:in `fail'
+[MinitestRetry] retry 'fail' count: 2,  msg: RuntimeError: parsing error\n    #{__FILE__}:45:in `fail'
+[MinitestRetry] retry 'fail' count: 3,  msg: RuntimeError: parsing error\n    #{__FILE__}:45:in `fail'
+    EOS
+
+    refute reporter.passed?
+    assert_equal expect, output
+  end
+
   def test_if_test_is_successful_in_middle_of_retry
     output = capture_stdout do
       retry_test = Class.new(Minitest::Test) do


### PR DESCRIPTION
It improves the debugging by providing the exact error message rather than the message "Unexpected exception" when an unexpected error is raised :
```
[MinitestRetry] retry 'test_abtest_first_visit' count: 1,  msg: Unexpected exception
```