### PR TITLE
Result in callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Minitest::Retry.use!(
 #### Callbacks
 The `on_failure` callback is executed each time a test fails:
 ```ruby
-Minitest::Retry.on_failure do |klass, test_name|
+Minitest::Retry.on_failure do |klass, test_name, result|
   # code omitted
 end
 ```
@@ -58,7 +58,7 @@ end
 
 The `on_retry` callback is executed each time a test is retried:
 ```ruby
-Minitest::Retry.on_retry do |klass, test_name, retry_count|
+Minitest::Retry.on_retry do |klass, test_name, retry_count, result|
   # code omitted
 end
 ```

--- a/lib/minitest/retry.rb
+++ b/lib/minitest/retry.rb
@@ -65,9 +65,9 @@ module Minitest
         result = super(klass, method_name)
         return result unless Minitest::Retry.failure_to_retry?(result.failures)
         if !result.skipped?
-          Minitest::Retry.failure_callback.call(klass, method_name) if Minitest::Retry.failure_callback
+          Minitest::Retry.failure_callback.call(klass, method_name, result) if Minitest::Retry.failure_callback
           Minitest::Retry.retry_count.times do |count|
-            Minitest::Retry.retry_callback.call(klass, method_name, count + 1) if Minitest::Retry.retry_callback
+            Minitest::Retry.retry_callback.call(klass, method_name, count + 1, result) if Minitest::Retry.retry_callback
             if Minitest::Retry.verbose && Minitest::Retry.io
               msg = "[MinitestRetry] retry '%s' count: %s,  msg: %s\n" %
                 [method_name, count + 1, result.failures.map(&:message).join(",")]


### PR DESCRIPTION
Adding in the results to the failure and retry callbacks.

I am currently working on finding flaky tests and found that the `klass` and `test_name` were not enough data to report on. By adding the `result` I was able to get useful info like the test file and expected/actual values for the test.
Figured others might find that useful as well.

Let me know if you need me to change anything on this PR. Thanks!