### PR TITLE
Add `result` parameter to `on_consistent_failure` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ end
 
 The `on_consistent_failure` callback is executed when a test consistently fails:
 ```ruby
-Minitest::Retry.on_consistent_failure do |klass, test_name|
+Minitest::Retry.on_consistent_failure do |klass, test_name, result|
   # code omitted
 end
 ```

--- a/lib/minitest/retry.rb
+++ b/lib/minitest/retry.rb
@@ -79,7 +79,7 @@ module Minitest
           end
 
           if Minitest::Retry.consistent_failure_callback && !result.failures.empty?
-            Minitest::Retry.consistent_failure_callback.call(klass, method_name)
+            Minitest::Retry.consistent_failure_callback.call(klass, method_name, result)
           end
         end
         result

--- a/test/minitest/retry_test.rb
+++ b/test/minitest/retry_test.rb
@@ -258,14 +258,15 @@ class Minitest::RetryTest < Minitest::Test
 
   def test_run_consistent_failure_callback_on_failure
     on_consistent_failure_block_call_count = 0
-    test_name, test_class, retry_test = nil
+    test_name, test_class, retry_test, result_in_callback = nil
     capture_stdout do
       retry_test = Class.new(Minitest::Test) do
         Minitest::Retry.use!
-        Minitest::Retry.on_consistent_failure do |klass, failed_test|
+        Minitest::Retry.on_consistent_failure do |klass, failed_test, result|
           on_consistent_failure_block_call_count += 1
           test_class = klass
           test_name = failed_test
+          result_in_callback = result
         end
 
         def fail
@@ -277,6 +278,8 @@ class Minitest::RetryTest < Minitest::Test
     assert_equal :fail, test_name
     assert_equal retry_test, test_class
     assert_equal 1, on_consistent_failure_block_call_count
+    refute_nil result_in_callback
+    assert_instance_of Minitest::Assertion, result_in_callback.failures[0]
   end
 
   class TestError < StandardError; end


### PR DESCRIPTION
This is an extension of #29, which added the `result` parameter to the `on_failure` and `on_retry` callbacks. It can be useful to have access to the result in the `on_consistent_failure` callback, too (and callbacks can still omit the result parameter if they don't want to use it). Now the callbacks all support the same parameters again.