### PR TITLE
add support for policy callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Minitest::Retry.use!(
 )
 ```
 
+#### Policy Callbacks
+
+These are optional in nature (useful to implement fine-grained policies).
+
+The `should_skip` callback is executed before a test is run:
+```ruby
+Minitest::Retry.should_skip do |klass, test_name|
+  # returning anything except nil/false will skip the test
+end
+```
+
 #### Callbacks
 The `on_failure` callback is executed each time a test fails:
 ```ruby

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Minitest::Retry.should_skip do |klass, test_name|
 end
 ```
 
+The `should_retry` callback is called after a test is run:
+```ruby
+Minitest::Retry.should_retry do |result|
+  # Use result.class, result.name and result.failures to decide.
+  # Calls Minitest::Retry.failure_to_retry? if not configured.
+end
+```
+
 #### Callbacks
 The `on_failure` callback is executed each time a test fails:
 ```ruby


### PR DESCRIPTION
The motivation for adding these callbacks is:

* we often need to skip tests dynamically e.g. based on whether an external service is available or not (`should_skip`)
* we want to retry all tests by default, except for some tests which we know are flaky (`should_retry`)