### PR TITLE
Add methods  to retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Minitest::Retry.use!(
   retry_count:  3,         # The number of times to retry. The default is 3.
   verbose: true,           # Whether or not to display the message at the time of retry. The default is true.
   io: $stdout,             # Display destination of retry when the message. The default is stdout.
-  exceptions_to_retry: []  # List of exceptions that will trigger a retry (when empty, all exceptions will).
+  exceptions_to_retry: [], # List of exceptions that will trigger a retry (when empty, all exceptions will).
+  methods_to_retry:    []  # List of methods that will trigger a retry (when empty, all methods will).
 )
 ```
 

--- a/lib/minitest/retry.rb
+++ b/lib/minitest/retry.rb
@@ -74,7 +74,7 @@ module Minitest
 
         result = super(klass, method_name)
 
-        klass_method_name = "#{klass.class.name}##{method_name}"
+        klass_method_name = "#{klass.name}##{method_name}"
         return result unless Minitest::Retry.failure_to_retry?(result.failures, klass_method_name)
         if !result.skipped?
           Minitest::Retry.failure_callback.call(klass, method_name, result) if Minitest::Retry.failure_callback

--- a/test/minitest/retry_test.rb
+++ b/test/minitest/retry_test.rb
@@ -190,10 +190,17 @@ class Minitest::RetryTest < Minitest::Test
     capture_stdout do
       retry_test = Class.new(Minitest::Test) do
         @@counter = 0
+
+        class << self
+          def name
+            'TestClass'
+          end
+        end
+
         def self.counter
           @@counter
         end
-        Minitest::Retry.use! methods_to_retry: ["#{self.class.name}#fail"]
+        Minitest::Retry.use! methods_to_retry: ["TestClass#fail"]
         def fail
           @@counter += 1;
           assert false, 'fail test'
@@ -209,10 +216,17 @@ class Minitest::RetryTest < Minitest::Test
     capture_stdout do
       retry_test = Class.new(Minitest::Test) do
         @@counter = 0
+
+        class << self
+          def name
+            'TestClass'
+          end
+        end
+
         def self.counter
           @@counter
         end
-        Minitest::Retry.use! methods_to_retry: ["#{self.class.name}#fail"]
+        Minitest::Retry.use! methods_to_retry: ["TestClass#fail"]
         def another_fail
           @@counter += 1;
           assert false, 'fail test'

--- a/test/minitest/retry_test.rb
+++ b/test/minitest/retry_test.rb
@@ -186,6 +186,44 @@ class Minitest::RetryTest < Minitest::Test
     end
   end
 
+  def test_retry_when_method_in_methods_to_retry
+    capture_stdout do
+      retry_test = Class.new(Minitest::Test) do
+        @@counter = 0
+        def self.counter
+          @@counter
+        end
+        Minitest::Retry.use! methods_to_retry: ["#{self.class.name}#fail"]
+        def fail
+          @@counter += 1;
+          assert false, 'fail test'
+        end
+      end
+      Minitest::Runnable.run_one_method(retry_test, :fail, self.reporter)
+
+      assert_equal 4, retry_test.counter
+    end
+  end
+
+  def test_donot_retry_when_not_in_methods_to_retry
+    capture_stdout do
+      retry_test = Class.new(Minitest::Test) do
+        @@counter = 0
+        def self.counter
+          @@counter
+        end
+        Minitest::Retry.use! methods_to_retry: ["#{self.class.name}#fail"]
+        def another_fail
+          @@counter += 1;
+          assert false, 'fail test'
+        end
+      end
+      Minitest::Runnable.run_one_method(retry_test, :another_fail, self.reporter)
+
+      assert_equal 1, retry_test.counter
+    end
+  end
+
   def test_run_failure_callback_on_failure
     on_failure_block_has_ran = false
     test_name, test_class, retry_test, result_in_callback = nil


### PR DESCRIPTION
Following the idea of `exceptions_to_retry` I added `methods_to_retry`

Example: 

```rb
    methods_to_retry: ["TestClass#testing_something"]

    class TestClass
      def testing_something
      end
    end
```
When `methods_to_retry` is not empty It retries only the methods showed up on the list.
When `methods_to_retry` is empty it retries all.
