### PR TITLE
Explicitly load `minitest` first

### DIFF
--- a/lib/minitest/retry.rb
+++ b/lib/minitest/retry.rb
@@ -1,3 +1,4 @@
+require "minitest"
 require "minitest/retry/version"
 
 module Minitest


### PR DESCRIPTION
`minitest-retry` depends on `minitest`.
If `minitest-retry` is loaded without `minitest`, the version check would not work correctly(`Minitest::Retry::VERSION` would use instead of `Minitest::VERSION`).